### PR TITLE
Remove RHEA id prefix from most semantic types

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,6 @@ export const APIMETA: MetaDataItemsObject = {
       'UNII',
       'KEGG',
       'UMLS',
-      'RHEA',
       'name',
     ],
     semantic: 'ChemicalSubstance',
@@ -102,7 +101,6 @@ export const APIMETA: MetaDataItemsObject = {
       INCHI: ['drugbank.inchi', 'chebi.inchi', 'chembl.inchi'],
       KEGG: ['drugbank.xrefs.kegg.cid'],
       LINCS: ['unichem.lincs'],
-      RHEA: ['chebi.xrefs.rhea'],
       name: ['chembl.pref_name', 'drugbank.name', 'umls.name', 'ginas.preferred_name', 'pharmgkb.name', 'chebi.name'],
     },
     additional_attributes_mapping: {
@@ -132,7 +130,6 @@ export const APIMETA: MetaDataItemsObject = {
       'KEGG',
       'UMLS',
       'LINCS',
-      'RHEA',
       'name',
     ],
     semantic: 'ChemicalSubstance',
@@ -154,7 +151,6 @@ export const APIMETA: MetaDataItemsObject = {
       INCHIKEY: ['drugbank.inchi_key', 'ginas.inchikey', 'unii.inchikey', 'chebi.inchikey'],
       INCHI: ['drugbank.inchi', 'chebi.inchi', 'chembl.inchi'],
       KEGG: ['drugbank.xrefs.kegg.cid'],
-      RHEA: ['chebi.xrefs.rhea'],
       name: ['chembl.pref_name', 'drugbank.name', 'umls.name', 'ginas.preferred_name', 'pharmgkb.name', 'chebi.name'],
     },
     additional_attributes_mapping: {
@@ -240,14 +236,13 @@ export const APIMETA: MetaDataItemsObject = {
     },
   },
   CellularComponent: {
-    id_ranks: ['GO', 'MetaCyc', 'RHEA', 'name'],
+    id_ranks: ['GO', 'MetaCyc', 'name'],
     semantic: 'CellularComponent',
     api_name: 'Gene Ontology Cellular Component API',
     url: 'https://biothings.ncats.io/go_cc/query',
     mapping: {
       GO: ['_id'],
       MetaCyc: ['xrefs.metacyc'],
-      RHEA: ['xrefs.rhea'],
       name: ['name'],
     },
   },


### PR DESCRIPTION
I believe RHEA IDs are actually "reactions" which best fit as molecular activities