### PR TITLE
feat: support Disease NCIT, SNOMEDCT IDs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -210,7 +210,7 @@ export const APIMETA: MetaDataItemsObject = {
       ORPHANET: ['hpo.orphanet', 'mondo.xrefs.orphanet'],
       GARD: ['mondo.xrefs.gard', 'disease_ontology.xrefs.gard'],
       HP: ['mondo.xrefs.hp'],
-      SNOMEDCT: ['umls.snomed.preferred', 'umls.snomed.non-preferred', 'disease_ontology.xrefs.snomedct_us_2020_09_01'],
+      SNOMEDCT: ['mondo.xrefs.sctid', 'umls.snomed.preferred', 'umls.snomed.non-preferred'],
       NCIT: ['mondo.xrefs.ncit', 'disease_ontology.xrefs.ncit']
     },
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -189,7 +189,7 @@ export const APIMETA: MetaDataItemsObject = {
     },
   },
   Disease: {
-    id_ranks: ['MONDO', 'DOID', 'OMIM', 'ORPHANET', 'EFO', 'UMLS', 'MESH', 'HP', 'GARD', 'name'],
+    id_ranks: ['MONDO', 'DOID', 'OMIM', 'ORPHANET', 'SNOMEDCT', 'NCIT', 'EFO', 'UMLS', 'MESH', 'HP', 'GARD', 'name'],
     semantic: 'Disease',
     api_name: 'mydisease.info',
     url: 'https://mydisease.info/v1/query',
@@ -210,6 +210,8 @@ export const APIMETA: MetaDataItemsObject = {
       ORPHANET: ['hpo.orphanet', 'mondo.xrefs.orphanet'],
       GARD: ['mondo.xrefs.gard', 'disease_ontology.xrefs.gard'],
       HP: ['mondo.xrefs.hp'],
+      SNOMEDCT: ['umls.snomed.preferred', 'umls.snomed.non-preferred', 'disease_ontology.xrefs.snomedct_us_2020_09_01'],
+      NCIT: ['mondo.xrefs.ncit', 'disease_ontology.xrefs.ncit']
     },
   },
   MolecularActivity: {


### PR DESCRIPTION
I don't have a development environment set up for this, so **check that the ID resolution works as expected before merging**. I've included some checks below:  

---


Checks for SNOMEDCT ID resolution  (these are subjects in the clinical risk kp api right now):
- input "SNOMEDCT:386033004" (neuropathy) -> output UMLS:C0442874, MONDO:0005244. This should hit the mondo.xrefs and umls.snomed fields.
- input "SNOMEDCT:2415007" (Lumbosacral radiculopathy (disorder)) -> output UMLS:C1263855, UMLS:C0154738. Should get TWO UMLS IDs out. 
- input "SNOMEDCT:76571007" (Septic shock (disorder)) -> no equivalent IDs...It looks like our mapping files don't have this disease in them. 

---

Checks for NCIT ID resolution (see note below, this isn't helpful for clinical risk kp api right now):
- input "NCIT:C3010" (endocrine gland neoplasm) -> output MONDO:0002082, DOID:170. This should hit the mondo and disease ontology xrefs. 
- input "NCIT:C116936" (polymicrogyria) -> output MONDO:0000087. This should hit the mondo.xrefs
- input "NCIT:C116994" (Lupus Anticoagulant Disorder) -> no equivalent IDs...It looks like our mapping files don't have this disease in them. 

Note: the only current NCIT ID in Clinical risk kp api is C116994 (Lupus Anticoagulant Disorder). I don't find any equivalent IDs from the mondo or disease ontology xrefs....