### PR TITLE
simple: remove DiseaseOrPhenotypicFeature

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -16,7 +16,6 @@ export type ResolvableSemanticTypes =
   | 'SequenceVariant'
   | 'ChemicalSubstance'
   | 'Disease'
-  | 'DiseaseOrPhenotypicFeature'
   | 'PhenotypicFeature'
   | 'MolecularActivity'
   | 'BiologicalProcess'
@@ -30,7 +29,6 @@ export enum ResolvableTypes {
   SequenceVariant = 'SequenceVariant',
   ChemicalSubstance = 'ChemicalSubstance',
   Disease = 'Disease',
-  DiseaseOrPhenotypicFeature = 'DiseaseOrPhenotypicFeature',
   PhenotypicFeature = 'PhenotypicFeature',
   MolecularActivity = 'MolecularActivity',
   BiologicalProcess = 'BiologicalProcess',


### PR DESCRIPTION
we don't have mappings directly to this in the config file, and things still seem to be working okay. Remove for now?

If Translator moves to using DiseaseOrPhenotypicFeature a lot in its query nodes that have IDs, we may want to add this back in and add mappings in the config file