### PR TITLE
fix: add batching to sri query to fix 414 errors

### DIFF
--- a/src/sri.ts
+++ b/src/sri.ts
@@ -57,7 +57,7 @@ function transformResults(results, semanticType: string): SRIResolverOutput {
       entry.attributes = {};
       entry.semanticType = entry.type[0].split(":")[1]; // get first semantic type without biolink prefix
       if (semanticType !== entry.semanticType) {
-        debug(`SRI resolved semantic type ${entry.semanticType} doesn't match input semantic type ${semanticType}. SRI Entry: ${JSON.stringify(entry, null, 2)}`);
+        debug(`SRI resolved semantic type ${entry.semanticType} doesn't match input semantic type ${semanticType} for curie ${entry.primaryID}.`);
       }
       entry.semanticTypes = entry.type;
 

--- a/src/sri.ts
+++ b/src/sri.ts
@@ -42,11 +42,11 @@ function transformResults(results, semanticType: string): SRIResolverOutput {
         _leafSemanticType: semanticType,
         semanticTypes: [semanticType],
         dbIDs: {
-          [id_type]: CURIE.ALWAYS_PREFIXED.includes(id_type) ? key : key.split(":")[1],
+          [id_type]: [CURIE.ALWAYS_PREFIXED.includes(id_type) ? key : key.split(":")[1]],
           name: [key]
         },
         _dbIDs: {
-          [id_type]: CURIE.ALWAYS_PREFIXED.includes(id_type) ? key : key.split(":")[1],
+          [id_type]: [CURIE.ALWAYS_PREFIXED.includes(id_type) ? key : key.split(":")[1]],
           name: [key]
         }
       };


### PR DESCRIPTION
- add batching to sri query to fix 414 errors. This happens when the length of the url query is greater than 65536
- Fix bug with dbIDs shape when curie can't be resolved
- shorten the debug printout