### PR TITLE
fix #329: Query SRI using post instead of get

### DIFF
--- a/__tests__/integration/sri_resolver.test.ts
+++ b/__tests__/integration/sri_resolver.test.ts
@@ -106,13 +106,14 @@ describe("Test SRI Resolver", () => {
   });
 
   test("Test large batch of inputs should be correctly resolved and should not give an error", async () => {
-    const fakeNCBIGeneInputs = [...Array(5000).keys()].map(item => 'NCBIGene:' + item.toString());
+    const fakeNCBIGeneInputs = [...Array(15000).keys()].map(item => 'NCBIGene:' + item.toString());
     let input = {
       Gene: fakeNCBIGeneInputs,
     };
     const res = await resolveSRI(input);
 
     expect(Object.keys(res)).toHaveLength(fakeNCBIGeneInputs.length);
+    expect(res["NCBIGene:1"]).toEqual(expect.any(Array));
   })
 
 });

--- a/src/sri.ts
+++ b/src/sri.ts
@@ -16,15 +16,12 @@ function combineInputs(userInput: ResolverInput): string[] {
 //input: array of curies
 //handles querying and batching of inputs
 async function query(api_input: string[]) {
-  let url: URL = new URL('https://nodenormalization-sri.renci.org/1.2/get_normalized_nodes');
+  let url = 'https://nodenormalization-sri.renci.org/1.2/get_normalized_nodes';
 
-  //SRI returns a 414 error if the length of the url query is greater than 65536, split into chunks of 1500 curies to be on the safe side (lower number if still running into 414 errors)
-  let chunked_input = _.chunk(api_input, 1500); 
+  let chunked_input = _.chunk(api_input, 10000);
 
   let axios_queries = chunked_input.map((input) => {
-    //@ts-ignore
-    url.search = new URLSearchParams(input.map(curie => ["curie", curie]));
-    return axios.get(url.toString());
+    return axios.post(url, {curies: input});
   });
 
   //convert res array into single object with all curies


### PR DESCRIPTION
Fixes https://github.com/biothings/BioThings_Explorer_TRAPI/issues/329. 

- use post instead of get request
- sends 10000 ids at once to SRI compared to 1500 before