### PR TITLE
Handle empty responses from node normalizer

### DIFF
--- a/src/sri.ts
+++ b/src/sri.ts
@@ -30,7 +30,11 @@ async function query(api_input: string[]) {
     });
     //convert res array into single object with all curies
     let res = await Promise.all(axios_queries);
-    res = res.map(r => r.data);
+    res = res.map((r, i) => {
+      return Object.keys(r.data).length
+        ? r.data
+        : Object.fromEntries(chunked_input[i].map(curie => [curie, null]));
+  });
     return Object.assign({}, ...res);
   } catch (err) {
     err.message = `SRI resolver failed: ${err.message}`;


### PR DESCRIPTION
Due to TranslatorSRI/NodeNormalization/issues/113, we occasionally get a response of `{}` from the node normalizer, which previously we didn't handle, causing a query to fail.

This PR simply checks for this case, and replaces the response with what we would expect: an object where each curie is a key pointing to `null`.