### PR TITLE
temp change: use dev NodeNormalizer url with improved UMLS support

### DIFF
--- a/src/sri.ts
+++ b/src/sri.ts
@@ -17,7 +17,7 @@ function combineInputs(userInput: ResolverInput): string[] {
 //input: array of curies
 //handles querying and batching of inputs
 async function query(api_input: string[]) {
-  let url = 'https://nodenorm.transltr.io/get_normalized_nodes';
+  let url = 'https://nodenormalization-sri.renci.org/1.3/get_normalized_nodes';
 
   let chunked_input = _.chunk(api_input, 5000);
   try {


### PR DESCRIPTION
I tested using this dev instance of Node Normalizer while testing https://github.com/biothings/bte_trapi_query_graph_handler/pull/121#issuecomment-1254346453. 

I think this improves UMLS coverage (however I still noticed some IDs where the names / labels hadn't been retrieved). It seems to run fine (no change in speed). 

I think we can run automated tests before merging. I dunno about running demotests - except to try stressing it and see if it still works aka labels are still retrieved for nodes). 