### PR TITLE
A small multitude of updates

### DIFF
--- a/__tests__/integration/sri_resolver.test.ts
+++ b/__tests__/integration/sri_resolver.test.ts
@@ -1,4 +1,5 @@
 import { resolveSRI } from '../../src/index';
+import { SRIBioEntity } from '../../src/common/types';
 
 describe("Test SRI Resolver", () => {
   test("Test old format", async () => {
@@ -10,15 +11,12 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:1017"]).toEqual(expect.any(Array));
-    expect(res["NCBIGene:1017"][0].primaryID).toEqual("NCBIGene:1017");
-    expect(res["NCBIGene:1017"][0].label).toEqual("CDK2");
-    expect(res["NCBIGene:1017"][0].semanticType).toEqual("Gene");
-    expect(res["NCBIGene:1017"][0].semanticTypes).toEqual(expect.any(Array));
-    expect(res["NCBIGene:1017"][0].dbIDs).toEqual(expect.any(Object));
-    expect(res["NCBIGene:1017"][0].dbIDs.NCBIGene).toEqual(expect.any(Array));
-    expect(res["NCBIGene:1017"][0].dbIDs.name).toEqual(expect.any(Array));
-    expect(res["NCBIGene:1017"][0].curies).toEqual(expect.any(Array));
+    expect(res["NCBIGene:1017"].primaryID).toEqual("NCBIGene:1017");
+    expect(res["NCBIGene:1017"].label).toEqual("CDK2");
+    expect(res["NCBIGene:1017"].primaryTypes).toEqual(["Gene"]);
+    expect(res["NCBIGene:1017"].semanticTypes).toEqual(expect.any(Array));
+    expect(res["NCBIGene:1017"].labelAliases).toEqual(expect.any(Array));
+    expect(res["NCBIGene:1017"].equivalentIDs).toEqual(expect.any(Array));
   });
 
   test("Test unresolvable curie/bad input", async () => {
@@ -27,19 +25,15 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:ABCD"]).toEqual(expect.any(Array));
-    expect(res["NCBIGene:ABCD"][0].semanticType).toEqual("Gene");
-    expect(res["NCBIGene:ABCD"][0].primaryID).toEqual("NCBIGene:ABCD");
-    expect(res["NCBIGene:ABCD"][0].label).toEqual("NCBIGene:ABCD");
-    expect(res["NCBIGene:ABCD"][0].dbIDs.name).toEqual(expect.any(Array));
-    expect(res["NCBIGene:ABCD"][0].dbIDs.NCBIGene).toEqual(expect.any(Array));
+    expect(res["NCBIGene:ABCD"].primaryTypes).toEqual(["Gene"]);
+    expect(res["NCBIGene:ABCD"].primaryID).toEqual("NCBIGene:ABCD");
+    expect(res["NCBIGene:ABCD"].label).toEqual("NCBIGene:ABCD");
+    expect(res["NCBIGene:ABCD"].labelAliases).toEqual(expect.any(Array));
 
-    expect(res["NCBIGene:GENE:1017"]).toEqual(expect.any(Array));
-    expect(res["NCBIGene:GENE:1017"][0].semanticType).toEqual("Gene");
-    expect(res["NCBIGene:GENE:1017"][0].primaryID).toEqual("NCBIGene:GENE:1017");
-    expect(res["NCBIGene:GENE:1017"][0].label).toEqual("NCBIGene:GENE:1017");
-    expect(res["NCBIGene:GENE:1017"][0].dbIDs.name).toEqual(expect.any(Array));
-    expect(res["NCBIGene:GENE:1017"][0].dbIDs.NCBIGene).toEqual(expect.any(Array));
+    expect(res["NCBIGene:GENE:1017"].primaryTypes).toEqual(["Gene"]);
+    expect(res["NCBIGene:GENE:1017"].primaryID).toEqual("NCBIGene:GENE:1017");
+    expect(res["NCBIGene:GENE:1017"].label).toEqual("NCBIGene:GENE:1017");
+    expect(res["NCBIGene:GENE:1017"].labelAliases).toEqual(expect.any(Array));
   });
 
   test("Test SRI Semantic type resolver with unknown", async () => {
@@ -48,8 +42,7 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:3778"]).toEqual(expect.any(Array));
-    expect(res["NCBIGene:3778"][0].semanticType).toEqual("Gene");
+    expect(res["NCBIGene:3778"].primaryTypes).toEqual(["Gene"]);
   })
 
   test("Test SRI Semantic type resolver with undefined", async () => {
@@ -58,8 +51,7 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:3778"]).toEqual(expect.any(Array));
-    expect(res["NCBIGene:3778"][0].semanticType).toEqual("Gene");
+    expect(res["NCBIGene:3778"].primaryTypes).toEqual(["Gene"]);
   })
 
   test("Test SRI Semantic type resolver with NamedThing", async () => {
@@ -68,8 +60,7 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:3778"]).toEqual(expect.any(Array));
-    expect(res["NCBIGene:3778"][0].semanticType).toEqual("Gene");
+    expect(res["NCBIGene:3778"].primaryTypes).toEqual(["Gene"]);
   })
 
   test("Test Same ID different semantic types", async () => {
@@ -79,9 +70,8 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:1017"].length).toBe(2);
-    expect(res["NCBIGene:1017"][0].semanticType).toEqual("Gene");
-    expect(res["NCBIGene:1017"][1].semanticType).toEqual("Disease");
+    expect(res["NCBIGene:1017"].primaryTypes.length).toBe(2);
+    expect(res["NCBIGene:1017"].primaryTypes).toEqual(["Gene", "Disease"])
   });
 
   test("Test using SRI to get semantic types", async () => {
@@ -90,8 +80,8 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["NCBIGene:1017"].length).toBe(1);
-    expect(res["NCBIGene:1017"][0].semanticType).toEqual("Gene");
+    expect(res).toHaveProperty("NCBIGene:1017");
+    expect(res["NCBIGene:1017"].primaryTypes).toContain("Gene");
   });
 
   test("Test handling semantic type conflicts", async () => {
@@ -100,9 +90,8 @@ describe("Test SRI Resolver", () => {
     };
     const res = await resolveSRI(input);
 
-    expect(res["PUBCHEM.COMPOUND:23680530"].length).toBe(2);
-    expect(res["PUBCHEM.COMPOUND:23680530"][0].semanticType).toEqual("MolecularMixture");
-    expect(res["PUBCHEM.COMPOUND:23680530"][1].semanticType).toEqual("SmallMolecule");
+    expect(res["PUBCHEM.COMPOUND:23680530"].primaryTypes.length).toBe(2);
+    expect(res["PUBCHEM.COMPOUND:23680530"].primaryTypes).toEqual(["MolecularMixture", "SmallMolecule"])
   });
 
   test("Test large batch of inputs should be correctly resolved and should not give an error", async () => {
@@ -113,7 +102,6 @@ describe("Test SRI Resolver", () => {
     const res = await resolveSRI(input);
 
     expect(Object.keys(res)).toHaveLength(fakeNCBIGeneInputs.length);
-    expect(res["NCBIGene:1"]).toEqual(expect.any(Array));
   })
 
 });

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -153,16 +153,35 @@ export interface IDOBject {
   identifier: string;
   label: string;
 }
-export interface SRIBioEntity extends IBioEntity {
-  _leafSemanticType: string; // @deprecated use semanticType instead
-  _dbIDs: DBIdsObject; // @deprecated use dbIDs instead
-  id: IDOBject;
-  equivalent_identifiers: IDOBject[];
+export interface SRIBioEntity {
+  primaryID: string; // SRI-preferred curie for this entity
+  equivalentIDs: string[]; // curies that also resolve to this entity
+  label: string; // SRI-preffered entity label
+  labelAliases: string[]; // other labels for this entity
+  // "main" semantic types for this entity, first is always the SRI-preferred type
+  primaryTypes: string[];
+  semanticTypes: string[]; // all types for this entity, up the hierarchy
+  attributes: DBIdsObject; // attributes attached to this entity
+}
+
+export interface IdentifierObject {
+  identifier: string;
+  label?: string;
+}
+
+export interface SRIResponseEntity {
+  id: IdentifierObject;
+  equivalent_identifiers: IdentifierObject[];
   type: string[];
+  information_content: number;
+}
+
+export interface SRIResponse {
+  [curie: string]: SRIResponseEntity;
 }
 
 export interface SRIResolverOutput {
-  [curie: string]: SRIBioEntity[];
+  [curie: string]: SRIBioEntity;
 }
 
 export interface ResolverInput {


### PR DESCRIPTION
This update has, due to time and overlapping of code touched by each feature, become a single amalgam update using one branch name across each module. As such, the changes across the whole update will be listed the same for each PR:

- Response from SRI resolver package has been refactored
- Record has been refactored to accommodate new resolved node structure
- Code across the modules has been refactored to use record instead of normalizedInfo where possible
- When calling APIs, raw responses are discarded as soon as transformed records are available
- Async handling has changed:
  - Responses are now kept 30 days instead of 7
  - Failed jobs are now kept for 1 day instead of being discarded immediately
  - Completed jobs are kept 90 days
  - Bull now uses the same redisClient system as the rest of BTE
  - Bull jobs are now executed in a thread, rather than a subprocess
  - Bull jobs are cancelled and marked failed after 2 hours of execution
- A Bull queue dashboard has been added at `/queues` endpoint
- redisClient now has a longer connection timeout, and a custom retry strategy
- some code has been moved to the edge manager for clarity
- BTE now considers records matching if they match a node original or primaryID that might somehow be missing from equivalentIDs, meaning fewer records are dropped in some circumstances
- Relevant tests have been updated